### PR TITLE
Stop injectors from injecting key => null

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ php:
   - 5.6
   - 7.0
   - 7.3
-  - nightly
 
 before_script:
   - composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 php:
   - 5.6
   - 7.0
-  - 7.1
+  - 7.4
   - nightly
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,3 @@ before_script:
   - composer install
 
 script: ./vendor/bin/phpunit --configuration phpunit.xml
-w

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,11 @@ language: php
 php:
   - 5.6
   - 7.0
-  - 7.4
+  - 7.3
   - nightly
 
 before_script:
   - composer install
 
 script: ./vendor/bin/phpunit --configuration phpunit.xml
+w

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.0.4 - 2019-12-06
+
+* Don't insert key from injectors when the value is null
+
 ## 4.0.3 - 2017-09-14
 
 * JSONValidator should just pass the json serializable validation result through

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   "require": {
     "php": ">=5.6.0",
     "superbalist/php-pubsub": "^2.0",
-    "composer/semver": "^1.4",
+    "composer/semver": "^1.5",
     "league/json-guard": "^0.5.1",
     "ramsey/uuid": "^3.5"
   },

--- a/src/EventManager.php
+++ b/src/EventManager.php
@@ -249,10 +249,15 @@ class EventManager
 
         foreach ($this->attributeInjectors as $injector) {
             if ($injector instanceof AttributeInjectorInterface) {
-                $values[$injector->getAttributeKey()] = $injector->getAttributeValue();
+                $v = $injector->getAttributeValue();
+                if ($v !== null) {
+                    $values[$injector->getAttributeKey()] = $v;
+                }
             } elseif (is_callable($injector)) {
                 $v = call_user_func($injector);
-                $values[$v['key']] = $v['value'];
+                if ($v['value'] !== null) {
+                    $values[$v['key']] = $v['value'];
+                }
             }
         }
 


### PR DESCRIPTION
https://citymob.atlassian.net/browse/CE-1937

Currently, when an attribute injector returns a null value, it will still insert { key => null } into the event. This change will prevent an injector from inserting a null value.